### PR TITLE
Timezones

### DIFF
--- a/datetimeparser/__init__.py
+++ b/datetimeparser/__init__.py
@@ -4,10 +4,4 @@ from datetimeparser import enums
 from datetimeparser import baseclasses
 from datetimeparser import parsermethods
 
-from datetimeparser.parser import Parser
-from datetimeparser.evaluator import Evaluator
-from datetimeparser.parsermethods import *
-from datetimeparser.enums import *
-from datetimeparser.baseclasses import *
-
 from datetimeparser.datetimeparser import parse

--- a/datetimeparser/baseclasses.py
+++ b/datetimeparser/baseclasses.py
@@ -31,6 +31,7 @@ class Concatenable(Printable):
 
         return new
 
+
 class AbsoluteDateTime(Concatenable):
     FIELDS = ["year", "month", "day", "hour", "minute", "second"]
 

--- a/datetimeparser/enums.py
+++ b/datetimeparser/enums.py
@@ -6,24 +6,37 @@ from .formulars import days_feb, eastern_calc, thanksgiving_calc, year_start
 
 class Constants:
     CHRISTMAS = Constant('christmas', ['xmas'], time_value=lambda year_time: datetime(year=year_time, month=12, day=25))
-    SILVESTER = Constant('silvester', ['new years eve'], time_value=lambda year_time: datetime(year=year_time, month=12, day=31))
+    SILVESTER = Constant('silvester', ['new years eve'],
+                         time_value=lambda year_time: datetime(year=year_time, month=12, day=31))
     EASTERN = Constant('eastern', ['easter'], time_value=eastern_calc)
-    NICHOLAS = Constant('nicholas', ['nicholas day'], time_value=lambda year_time: datetime(year=year_time, month=12, day=6))
+    NICHOLAS = Constant('nicholas', ['nicholas day'],
+                        time_value=lambda year_time: datetime(year=year_time, month=12, day=6))
     HALLOWEEN = Constant('halloween', time_value=lambda year_time: datetime(year=year_time, month=10, day=31))
-    APRIL_FOOLS_DAY = Constant('april fools day', ['april fool day'], time_value=lambda year_time: datetime(year=year_time, month=4, day=1))
+    APRIL_FOOLS_DAY = Constant('april fools day', ['april fool day'],
+                               time_value=lambda year_time: datetime(year=year_time, month=4, day=1))
     THANKSGIVING = Constant('thanksgiving', time_value=thanksgiving_calc)
-    SAINT_PATRICKS_DAY = Constant('saint patrick\'s day', ['saint patricks day', 'st. patrick\'s day', 'saint pt. day', 'st patrick\'s day', 'st patricks day'], time_value=lambda year_time: datetime(year=year_time, month=3, day=17))
-    VALENTINES_DAY = Constant('valentines day', ['valentine', 'valentine day'], time_value=lambda year_time: datetime(year=year_time, month=2, day=14))
+    SAINT_PATRICKS_DAY = Constant('saint patrick\'s day', ['saint patricks day', 'st. patrick\'s day', 'saint pt. day', 'st patrick\'s day', 'st patricks day'],
+                                  time_value=lambda year_time: datetime(year=year_time, month=3, day=17))
+    VALENTINES_DAY = Constant('valentines day', ['valentine', 'valentine day'],
+                              time_value=lambda year_time: datetime(year=year_time, month=2, day=14))
 
-    SUMMER_BEGIN = Constant('summer begin', ['summer', 'begin of summer', 'begin of the summer'], time_value=lambda year_time: datetime(year=year_time, month=6, day=1))
-    WINTER_BEGIN = Constant('winter begin', ['winter', 'begin of winter', 'begin of the winter'], time_value=lambda year_time: datetime(year=year_time, month=12, day=1))
-    SPRING_BEGIN = Constant('spring begin', ['spring', 'begin of spring', 'begin of the spring'], time_value=lambda year_time: datetime(year=year_time, month=3, day=1))
+    SUMMER_BEGIN = Constant('summer begin', ['summer', 'begin of summer', 'begin of the summer'],
+                            time_value=lambda year_time: datetime(year=year_time, month=6, day=1))
+    WINTER_BEGIN = Constant('winter begin', ['winter', 'begin of winter', 'begin of the winter'],
+                            time_value=lambda year_time: datetime(year=year_time, month=12, day=1))
+    SPRING_BEGIN = Constant('spring begin', ['spring', 'begin of spring', 'begin of the spring'],
+                            time_value=lambda year_time: datetime(year=year_time, month=3, day=1))
     FALL_BEGIN = Constant('fall begin', ['fall', 'begin of fall', 'begin of the fall', 'autumn begin', 'autumn',
-                                         'begin of autumn', 'begin of the autumn'], time_value=lambda year_time: datetime(year=year_time, month=9, day=1))
-    SUMMER_END = Constant('summer end', ['end of summer', 'end of the summer'], time_value=lambda year_time: datetime(year=year_time, month=8, day=31, hour=23, minute=59, second=59))
-    WINTER_END = Constant('winter end', ['end of winter', 'end of the winter'], time_value=lambda year_time: datetime(year=year_time, month=2, day=days_feb(year_time), hour=23, minute=59, second=59))
-    SPRING_END = Constant('spring end', ['end of spring', 'end of the spring'], time_value=lambda year_time: datetime(year=year_time, month=5, day=31, hour=23, minute=59, second=59))
-    FALL_END = Constant('fall end', ['end of fall', 'end of the fall', 'autumn end', 'end of autumn', 'end of the autumn'], time_value=lambda year_time: datetime(year=year_time, month=11, day=30, hour=23, minute=59, second=59))
+                                         'begin of autumn', 'begin of the autumn'],
+                          time_value=lambda year_time: datetime(year=year_time, month=9, day=1))
+    SUMMER_END = Constant('summer end', ['end of summer', 'end of the summer'],
+                          time_value=lambda year_time: datetime(year=year_time, month=8, day=31, hour=23, minute=59, second=59))
+    WINTER_END = Constant('winter end', ['end of winter', 'end of the winter'],
+                          time_value=lambda year_time: datetime(year=year_time, month=2, day=days_feb(year_time), hour=23, minute=59, second=59))
+    SPRING_END = Constant('spring end', ['end of spring', 'end of the spring'],
+                          time_value=lambda year_time: datetime(year=year_time, month=5, day=31, hour=23, minute=59, second=59))
+    FALL_END = Constant('fall end', ['end of fall', 'end of the fall', 'autumn end', 'end of autumn', 'end of the autumn'],
+                        time_value=lambda year_time: datetime(year=year_time, month=11, day=30, hour=23, minute=59, second=59))
 
     MORNING = Constant('morning', ['at morning', 'in the next morning', 'in the morning'])
     EVENING = Constant('evening', ['at evening', 'in the next evening', 'in the evening'])
@@ -31,12 +44,16 @@ class Constants:
 
     BEGIN_AOC = Constant('aoc begin', ['aoc', 'next aoc', 'begin of aoc', 'begin of the aoc', 'advent of code begin',
                                        'advent of code', 'next advent of code', 'begin of advent of code',
-                                       'begin of the advent of code'], time_value=lambda year_time: datetime(year=year_time, month=12, day=1, hour=6))
+                                       'begin of the advent of code'],
+                         time_value=lambda year_time: datetime(year=year_time, month=12, day=1, hour=6))
     END_AOC = Constant('aoc end', ['end of aoc', 'end of the aoc', 'advent of code end', 'end of advent of code',
-                                   'end of the advent of code'], time_value=lambda year_time: datetime(year=year_time, month=12, day=26, hour=6))
+                                   'end of the advent of code'],
+                       time_value=lambda year_time: datetime(year=year_time, month=12, day=26, hour=6))
 
-    END_OF_YEAR = Constant('end of year', ['the end of year', 'the end of the year', 'end of the year'], time_value=lambda year_time: datetime(year=year_time, month=12, day=31, hour=23, minute=59, second=59))
-    BEGIN_OF_YEAR = Constant('begin of year', ['the begin of year', 'the begin of the year', 'begin of the year'], time_value=year_start)
+    END_OF_YEAR = Constant('end of year', ['the end of year', 'the end of the year', 'end of the year'],
+                           time_value=lambda year_time: datetime(year=year_time, month=12, day=31, hour=23, minute=59, second=59))
+    BEGIN_OF_YEAR = Constant('begin of year', ['the begin of year', 'the begin of the year', 'begin of the year'],
+                             time_value=year_start)
 
     INFINITY = Constant('infinity', ['inf'], value=-1)
 

--- a/datetimeparser/enums.py
+++ b/datetimeparser/enums.py
@@ -1,26 +1,29 @@
-from .baseclasses import Constant, Constant, MethodEnum
+from datetime import datetime, timedelta
+
+from .baseclasses import Constant, MethodEnum
+from .formulars import days_feb, eastern_calc, thanksgiving_calc, year_start
 
 
 class Constants:
-    CHRISTMAS = Constant('christmas', ['xmas'])
-    SILVESTER = Constant('silvester', ['new years eve'])
-    EASTERN = Constant('eastern', ['easter'])
-    NICHOLAS = Constant('nicholas', ['nicholas day'])
-    HALLOWEEN = Constant('halloween')
-    APRIL_FOOLS_DAY = Constant('april fools day', ['april fool day'])
-    THANKSGIVING = Constant('thanksgiving')
-    SAINT_PATRICKS_DAY = Constant('saint patrick\'s day', ['saint patricks day', 'st. patrick\'s day', 'saint pt. day', 'st patrick\'s day', 'st patricks day'])
-    VALENTINES_DAY = Constant('valentines day', ['valentine', 'valentine day'])
+    CHRISTMAS = Constant('christmas', ['xmas'], time_value=lambda year_time: datetime(year=year_time, month=12, day=25))
+    SILVESTER = Constant('silvester', ['new years eve'], time_value=lambda year_time: datetime(year=year_time, month=12, day=31))
+    EASTERN = Constant('eastern', ['easter'], time_value=eastern_calc)
+    NICHOLAS = Constant('nicholas', ['nicholas day'], time_value=lambda year_time: datetime(year=year_time, month=12, day=6))
+    HALLOWEEN = Constant('halloween', time_value=lambda year_time: datetime(year=year_time, month=10, day=31))
+    APRIL_FOOLS_DAY = Constant('april fools day', ['april fool day'], time_value=lambda year_time: datetime(year=year_time, month=4, day=1))
+    THANKSGIVING = Constant('thanksgiving', time_value=thanksgiving_calc)
+    SAINT_PATRICKS_DAY = Constant('saint patrick\'s day', ['saint patricks day', 'st. patrick\'s day', 'saint pt. day', 'st patrick\'s day', 'st patricks day'], time_value=lambda year_time: datetime(year=year_time, month=3, day=17))
+    VALENTINES_DAY = Constant('valentines day', ['valentine', 'valentine day'], time_value=lambda year_time: datetime(year=year_time, month=2, day=14))
 
-    SUMMER_BEGIN = Constant('summer begin', ['summer', 'begin of summer', 'begin of the summer'])
-    WINTER_BEGIN = Constant('winter begin', ['winter', 'begin of winter', 'begin of the winter'])
-    SPRING_BEGIN = Constant('spring begin', ['spring', 'begin of spring', 'begin of the spring'])
+    SUMMER_BEGIN = Constant('summer begin', ['summer', 'begin of summer', 'begin of the summer'], time_value=lambda year_time: datetime(year=year_time, month=6, day=1))
+    WINTER_BEGIN = Constant('winter begin', ['winter', 'begin of winter', 'begin of the winter'], time_value=lambda year_time: datetime(year=year_time, month=12, day=1))
+    SPRING_BEGIN = Constant('spring begin', ['spring', 'begin of spring', 'begin of the spring'], time_value=lambda year_time: datetime(year=year_time, month=3, day=1))
     FALL_BEGIN = Constant('fall begin', ['fall', 'begin of fall', 'begin of the fall', 'autumn begin', 'autumn',
-                                         'begin of autumn', 'begin of the autumn'])
-    SUMMER_END = Constant('summer end', ['end of summer', 'end of the summer'])
-    WINTER_END = Constant('winter end', ['end of winter', 'end of the winter'])
-    SPRING_END = Constant('spring end', ['end of spring', 'end of the spring'])
-    FALL_END = Constant('fall end', ['end of fall', 'end of the fall', 'autumn end', 'end of autumn', 'end of the autumn'])
+                                         'begin of autumn', 'begin of the autumn'], time_value=lambda year_time: datetime(year=year_time, month=9, day=1))
+    SUMMER_END = Constant('summer end', ['end of summer', 'end of the summer'], time_value=lambda year_time: datetime(year=year_time, month=8, day=31, hour=23, minute=59, second=59))
+    WINTER_END = Constant('winter end', ['end of winter', 'end of the winter'], time_value=lambda year_time: datetime(year=year_time, month=2, day=days_feb(year_time), hour=23, minute=59, second=59))
+    SPRING_END = Constant('spring end', ['end of spring', 'end of the spring'], time_value=lambda year_time: datetime(year=year_time, month=5, day=31, hour=23, minute=59, second=59))
+    FALL_END = Constant('fall end', ['end of fall', 'end of the fall', 'autumn end', 'end of autumn', 'end of the autumn'], time_value=lambda year_time: datetime(year=year_time, month=11, day=30, hour=23, minute=59, second=59))
 
     MORNING = Constant('morning', ['at morning', 'in the next morning', 'in the morning'])
     EVENING = Constant('evening', ['at evening', 'in the next evening', 'in the evening'])
@@ -28,14 +31,14 @@ class Constants:
 
     BEGIN_AOC = Constant('aoc begin', ['aoc', 'next aoc', 'begin of aoc', 'begin of the aoc', 'advent of code begin',
                                        'advent of code', 'next advent of code', 'begin of advent of code',
-                                       'begin of the advent of code'])
+                                       'begin of the advent of code'], time_value=lambda year_time: datetime(year=year_time, month=12, day=1, hour=6))
     END_AOC = Constant('aoc end', ['end of aoc', 'end of the aoc', 'advent of code end', 'end of advent of code',
-                                   'end of the advent of code'])
+                                   'end of the advent of code'], time_value=lambda year_time: datetime(year=year_time, month=12, day=26, hour=6))
 
-    END_OF_YEAR = Constant('end of year', ['the end of year', 'the end of the year', 'end of the year'])
-    BEGIN_OF_YEAR = Constant('begin of year', ['the begin of year', 'the begin of the year', 'begin of the year'])
+    END_OF_YEAR = Constant('end of year', ['the end of year', 'the end of the year', 'end of the year'], time_value=lambda year_time: datetime(year=year_time, month=12, day=31, hour=23, minute=59, second=59))
+    BEGIN_OF_YEAR = Constant('begin of year', ['the begin of year', 'the begin of the year', 'begin of the year'], time_value=year_start)
 
-    INFINITY = Constant('infinity', ['inf'])  # Removed NekoFanatic from this list
+    INFINITY = Constant('infinity', ['inf'], value=-1)
 
     TODAY = Constant('today')
     TOMORROW = Constant('tomorrow')
@@ -188,30 +191,30 @@ class DatetimeConstants:
 
 
 class WeekdayConstants:
-    MONDAY = Constant('monday')
-    TUESDAY = Constant('tuesday')
-    WEDNESDAY = Constant('wednesday')
-    THURSDAY = Constant('thursday')
-    FRIDAY = Constant('friday')
-    SATURDAY = Constant('saturday')
-    SUNDAY = Constant('sunday')
+    MONDAY = Constant('monday', time_value=lambda date: f"{date + timedelta((0 - date.weekday()) % 7)}")
+    TUESDAY = Constant('tuesday', time_value=lambda date: f"{date + timedelta((1 - date.weekday()) % 7)}")
+    WEDNESDAY = Constant('wednesday', time_value=lambda date: f"{date + timedelta((2 - date.weekday()) % 7)}")
+    THURSDAY = Constant('thursday', time_value=lambda date: f"{date + timedelta((3 - date.weekday()) % 7)}")
+    FRIDAY = Constant('friday', time_value=lambda date: f"{date + timedelta((4 - date.weekday()) % 7)}")
+    SATURDAY = Constant('saturday', time_value=lambda date: f"{date + timedelta((5 - date.weekday()) % 7)}")
+    SUNDAY = Constant('sunday', time_value=lambda date: f"{date + timedelta((6 - date.weekday()) % 7)}")
 
     ALL = [MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY]
 
 
 class MonthConstants:
-    JANUARY = Constant('january', ['jan'])
-    FEBRUARY = Constant('february', ['feb'])
-    MARCH = Constant('march', ['mar'])
-    APRIL = Constant('april', ['apr'])
-    MAY = Constant('may')
-    JUNE = Constant('june', ['jun'])
-    JULY = Constant('july', ['jul'])
-    AUGUST = Constant('august', ['aug'])
-    SEPTEMBER = Constant('september', ['sep'])
-    OCTOBER = Constant('october', ['oct'])
-    NOVEMBER = Constant('november', ['nov'])
-    DECEMBER = Constant('december', ['dec'])
+    JANUARY = Constant('january', ['jan'], time_value=lambda year_time: datetime(year=year_time, month=1, day=1))
+    FEBRUARY = Constant('february', ['feb'], time_value=lambda year_time: datetime(year=year_time, month=2, day=1))
+    MARCH = Constant('march', ['mar'], time_value=lambda year_time: datetime(year=year_time, month=3, day=1))
+    APRIL = Constant('april', ['apr'], time_value=lambda year_time: datetime(year=year_time, month=4, day=1))
+    MAY = Constant('may', time_value=lambda year_time: datetime(year=year_time, month=5, day=1))
+    JUNE = Constant('june', ['jun'], time_value=lambda year_time: datetime(year=year_time, month=6, day=1))
+    JULY = Constant('july', ['jul'], time_value=lambda year_time: datetime(year=year_time, month=7, day=1))
+    AUGUST = Constant('august', ['aug'], time_value=lambda year_time: datetime(year=year_time, month=8, day=1))
+    SEPTEMBER = Constant('september', ['sep'], time_value=lambda year_time: datetime(year=year_time, month=9, day=1))
+    OCTOBER = Constant('october', ['oct'], time_value=lambda year_time: datetime(year=year_time, month=10, day=1))
+    NOVEMBER = Constant('november', ['nov'], time_value=lambda year_time: datetime(year=year_time, month=11, day=1))
+    DECEMBER = Constant('december', ['dec'], time_value=lambda year_time: datetime(year=year_time, month=12, day=1))
 
     ALL = [JANUARY, FEBRUARY, MARCH, APRIL, MAY, JUNE, JULY, AUGUST, SEPTEMBER, OCTOBER, NOVEMBER, DECEMBER]
 

--- a/datetimeparser/evaluator.py
+++ b/datetimeparser/evaluator.py
@@ -7,13 +7,11 @@ from .enums import *
 
 
 class Evaluator:
-
-    def __init__(self, parsed_object: tuple, tz: str = None):
-
+    def __init__(self, parsed_object, tz="Europe/Berlin"):
         try:
             tiz = timezone(tz)
         except UnknownTimeZoneError:
-            tiz = timezone("Europe/Berlin")
+            raise ValueError("Unknown timezone: {}".format(tz))
 
         self.parsed_object_type = parsed_object[0]
         self.parsed_object_content: Union[list, AbsoluteDateTime, RelativeDateTime] = parsed_object[1]

--- a/datetimeparser/evaluator.py
+++ b/datetimeparser/evaluator.py
@@ -1,108 +1,24 @@
-from datetime import datetime, timedelta
 from dateutil.relativedelta import relativedelta
 from typing import Union
-from pytz import timezone
+from pytz import timezone, UnknownTimeZoneError
 
-from .enums import *
 from .baseclasses import *
-
-
-def eastern_calc(year_time: int) -> datetime:
-    a = year_time % 19
-    k = year_time // 100
-    m = 15 + (3 * k + 3) // 4 - (8 * k + 13) // 25
-    d = (19 * a + m) % 30
-    s = 2 - (3 * k + 3) // 4
-    r = d // 29 + (d // 28 - d // 29) * (a // 11)
-    og = 21 + d + r
-    sz = 7 - (year_time + year_time // 4 + s) % 7
-    oe = 7 - (og - sz) % 7
-    os = og + oe
-
-    if os > 32:
-        return datetime(year=year_time, month=4, day=(os-31))
-    else:
-        return datetime(year=year_time, month=3, day=os)
-
-
-def thanksgiving_calc(year_time: int) -> datetime:
-    year_out = datetime(year=year_time, month=11, day=29)
-    date_out = datetime(year=year_time, month=11, day=3)
-    return year_out - timedelta(days=(date_out.weekday() + 2))
-
-
-def days_feb(year_time: int) -> int:
-    if int(year_time) % 400 == 0 or int(year_time) % 4 == 0 and not int(year_time) % 100 == 0:
-        return 29
-    else:
-        return 28
-
-
-def year(year_time: int) -> datetime:
-    return datetime(year=year_time, month=1, day=1)
+from .enums import *
 
 
 class Evaluator:
-    CURRENT_DATE: datetime = datetime.strptime(datetime.strftime(datetime.now(tz=timezone("Europe/Berlin")), "%Y-%m-%d"), "%Y-%m-%d")
-    CURRENT_DATETIME: datetime = datetime.strptime(datetime.strftime(datetime.now(tz=timezone("Europe/Berlin")), "%Y-%m-%d %H:%M:%S"), "%Y-%m-%d %H:%M:%S")
 
-    EVENTS = {
-        "silvester": lambda year_time: datetime(year=year_time, month=12, day=31),
-        "nicholas": lambda year_time: datetime(year=year_time, month=12, day=6),
-        "christmas": lambda year_time: datetime(year=year_time, month=12, day=25),
-        "halloween": lambda year_time: datetime(year=year_time, month=10, day=31),
-        "april fools day": lambda year_time: datetime(year=year_time, month=4, day=1),
-        "eastern": eastern_calc,
-        "thanksgiving": thanksgiving_calc,
-        "saint patrick's day": lambda year_time: datetime(year=year_time, month=3, day=17),
-        "valentines day": lambda year_time: datetime(year=year_time, month=2, day=14),
+    def __init__(self, parsed_object: tuple, tz: str = None):
 
-        # meteorological dates, if someone has any problem with that... -> fork this project, build a function for that and create a pull request :)
-        "spring begin": lambda year_time: datetime(year=year_time, month=3, day=1),
-        "spring end": lambda year_time: datetime(year=year_time, month=5, day=31, hour=23, minute=59, second=59),
-        "summer begin": lambda year_time: datetime(year=year_time, month=6, day=1),
-        "summer end": lambda year_time: datetime(year=year_time, month=8, day=31, hour=23, minute=59, second=59),
-        "fall begin": lambda year_time: datetime(year=year_time, month=9, day=1),
-        "fall end": lambda year_time: datetime(year=year_time, month=11, day=30, hour=23, minute=59, second=59),
-        "winter begin": lambda year_time: datetime(year=year_time, month=12, day=1),
-        "winter end": lambda year_time: datetime(year=year_time, month=2, day=days_feb(year_time), hour=23, minute=59, second=59),
+        try:
+            tiz = timezone(tz)
+        except UnknownTimeZoneError:
+            tiz = timezone("Europe/Berlin")
 
-        "aoc begin": lambda year_time: datetime(year=year_time, month=12, day=1, hour=6),
-        "aoc end": lambda year_time: datetime(year=year_time, month=12, day=26, hour=6),
-
-        "end of year": lambda year_time: datetime(year=year_time, month=12, day=31, hour=23, minute=59, second=59),
-
-        "infinity": -1
-    }
-
-    DAYS = {
-        "monday": f"{CURRENT_DATE + timedelta((0 - CURRENT_DATE.weekday()) % 7)}",
-        "tuesday": f"{CURRENT_DATE + timedelta((1 - CURRENT_DATE.weekday()) % 7)}",
-        "wednesday": f"{CURRENT_DATE + timedelta((2 - CURRENT_DATE.weekday()) % 7)}",
-        "thursday": f"{CURRENT_DATE + timedelta((3 - CURRENT_DATE.weekday()) % 7)}",
-        "friday": f"{CURRENT_DATE + timedelta((4 - CURRENT_DATE.weekday()) % 7)}",
-        "saturday": f"{CURRENT_DATE + timedelta((5 - CURRENT_DATE.weekday()) % 7)}",
-        "sunday": f"{CURRENT_DATE + timedelta((6 - CURRENT_DATE.weekday()) % 7)}"
-    }
-
-    MONTHS = {
-        "january": lambda year_time: datetime(year=year_time, month=1, day=1),
-        "february": lambda year_time: datetime(year=year_time, month=2, day=1),
-        "march": lambda year_time: datetime(year=year_time, month=3, day=1),
-        "april": lambda year_time: datetime(year=year_time, month=4, day=1),
-        "may": lambda year_time: datetime(year=year_time, month=5, day=1),
-        "june": lambda year_time: datetime(year=year_time, month=6, day=1),
-        "july": lambda year_time: datetime(year=year_time, month=7, day=1),
-        "august": lambda year_time: datetime(year=year_time, month=8, day=1),
-        "september": lambda year_time: datetime(year=year_time, month=9, day=1),
-        "october": lambda year_time: datetime(year=year_time, month=10, day=1),
-        "november": lambda year_time: datetime(year=year_time, month=11, day=1),
-        "december": lambda year_time: datetime(year=year_time, month=12, day=1)
-    }
-
-    def __init__(self, parsed_object: list):
         self.parsed_object_type = parsed_object[0]
         self.parsed_object_content: Union[list, AbsoluteDateTime, RelativeDateTime] = parsed_object[1]
+        self.current_date: datetime = datetime.strptime(datetime.strftime(datetime.now(tz=tiz), "%Y-%m-%d"), "%Y-%m-%d")
+        self.current_datetime: datetime = datetime.strptime(datetime.strftime(datetime.now(tz=tiz), "%Y-%m-%d %H:%M:%S"), "%Y-%m-%d %H:%M:%S")
 
     def evaluate(self) -> Union[datetime, int, None]:
         ev_out = AbsoluteDateTime()
@@ -111,9 +27,9 @@ class Evaluator:
 
             parsed_time: AbsoluteDateTime = self.parsed_object_content
 
-            ev_out.year = self.CURRENT_DATETIME.year if parsed_time.year == 0 else parsed_time.year
-            ev_out.month = self.CURRENT_DATETIME.month if parsed_time.month == 0 else parsed_time.month
-            ev_out.day = self.CURRENT_DATETIME.day if parsed_time.day == 0 else parsed_time.day
+            ev_out.year = self.current_datetime.year if parsed_time.year == 0 else parsed_time.year
+            ev_out.month = self.current_datetime.month if parsed_time.month == 0 else parsed_time.month
+            ev_out.day = self.current_datetime.day if parsed_time.day == 0 else parsed_time.day
             ev_out.hour = parsed_time.hour
             ev_out.minute = parsed_time.minute
             ev_out.second = parsed_time.second
@@ -123,32 +39,37 @@ class Evaluator:
 
         if self.parsed_object_type == Method.CONSTANTS:
 
-            dt: datetime = self.CURRENT_DATETIME
+            dt: datetime = self.current_datetime
 
             if len(self.parsed_object_content) == 2:
 
                 if isinstance(self.parsed_object_content[0], Constant):
                     object_type: Constant = self.parsed_object_content[0]
                     object_year: AbsoluteDateTime = self.parsed_object_content[1].year
-                    dt = self.EVENTS[str(object_type.name)](object_year)
-                    if self.CURRENT_DATETIME > dt and object_year == 0:
+                    dt = object_type.time_value(object_year)
+                    if self.current_datetime > dt and object_year == 0:
                         dt += relativedelta(years=1)
 
             else:
-                if self.parsed_object_content[0].name in self.EVENTS:
-                    if self.parsed_object_content[0].name == "infinity":
-                        return self.EVENTS["infinity"]
-                    dt = self.EVENTS[str(self.parsed_object_content[0].name)](self.CURRENT_DATETIME.year)
-                    if self.CURRENT_DATETIME > dt:
-                        dt += relativedelta(years=1)
-                elif self.parsed_object_content[0].name in self.DAYS:
-                    dt = datetime.strptime(f"{self.DAYS[str(self.parsed_object_content[0].name)].format(self.CURRENT_DATETIME.year)}", "%Y-%m-%d %H:%M:%S")
+
+                object_type: Constant = self.parsed_object_content[0]
+
+                if object_type.name == "infinity":
+                    return object_type.value
+
+                elif object_type in [obj for obj in WeekdayConstants.ALL]:
+                    return object_type.time_value(self.current_datetime)
+
+                dt = object_type.time_value(self.current_datetime.year)
+                if self.current_datetime > dt:
+                    dt += relativedelta(years=1)
+
             ev_out.year, ev_out.month, ev_out.day = dt.year, dt.month, dt.day
             ev_out.hour, ev_out.minute, ev_out.second = dt.hour, dt.minute, dt.second
 
         if self.parsed_object_type == Method.RELATIVE_DATETIMES:
 
-            new = self.CURRENT_DATETIME
+            new = self.current_datetime
 
             new += relativedelta(
                 years=self.parsed_object_content.years,
@@ -166,7 +87,7 @@ class Evaluator:
         if self.parsed_object_type == Method.DATETIME_DELTA_CONSTANTS:
 
             relative_time: RelativeDateTime = self.parsed_object_content
-            now: datetime = self.CURRENT_DATE
+            now: datetime = self.current_date
 
             ev_out.year, ev_out.month, ev_out.day = now.year, now.month, now.day
             ev_out.hour, ev_out.minute, ev_out.second = relative_time.hours, relative_time.minutes, relative_time.seconds

--- a/datetimeparser/evaluator.py
+++ b/datetimeparser/evaluator.py
@@ -1,6 +1,6 @@
 from dateutil.relativedelta import relativedelta
-from typing import Union
 from pytz import timezone, UnknownTimeZoneError
+from typing import Union
 
 from .baseclasses import *
 from .enums import *
@@ -22,7 +22,6 @@ class Evaluator:
         ev_out = AbsoluteDateTime()
 
         if self.parsed_object_type == Method.ABSOLUTE_DATE_FORMATS:
-
             parsed_time: AbsoluteDateTime = self.parsed_object_content
 
             ev_out.year = self.current_datetime.year if parsed_time.year == 0 else parsed_time.year
@@ -36,26 +35,24 @@ class Evaluator:
             pass
 
         if self.parsed_object_type == Method.CONSTANTS:
-
             dt: datetime = self.current_datetime
 
             if len(self.parsed_object_content) == 2:
-
                 if isinstance(self.parsed_object_content[0], Constant):
                     object_type: Constant = self.parsed_object_content[0]
                     object_year: AbsoluteDateTime = self.parsed_object_content[1].year
                     dt = object_type.time_value(object_year)
+
                     if self.current_datetime > dt and object_year == 0:
                         dt += relativedelta(years=1)
 
             else:
-
                 object_type: Constant = self.parsed_object_content[0]
 
                 if object_type.name == "infinity":
                     return object_type.value
 
-                elif object_type in [obj for obj in WeekdayConstants.ALL]:
+                elif object_type in WeekdayConstants.ALL:
                     return object_type.time_value(self.current_datetime)
 
                 dt = object_type.time_value(self.current_datetime.year)
@@ -66,7 +63,6 @@ class Evaluator:
             ev_out.hour, ev_out.minute, ev_out.second = dt.hour, dt.minute, dt.second
 
         if self.parsed_object_type == Method.RELATIVE_DATETIMES:
-
             new = self.current_datetime
 
             new += relativedelta(
@@ -83,7 +79,6 @@ class Evaluator:
             ev_out.hour, ev_out.minute, ev_out.second = new.hour, new.minute, new.second
 
         if self.parsed_object_type == Method.DATETIME_DELTA_CONSTANTS:
-
             relative_time: RelativeDateTime = self.parsed_object_content
             now: datetime = self.current_date
 

--- a/datetimeparser/formulars.py
+++ b/datetimeparser/formulars.py
@@ -1,0 +1,36 @@
+from datetime import datetime, timedelta
+
+
+def eastern_calc(year_time: int) -> datetime:
+    a = year_time % 19
+    k = year_time // 100
+    m = 15 + (3 * k + 3) // 4 - (8 * k + 13) // 25
+    d = (19 * a + m) % 30
+    s = 2 - (3 * k + 3) // 4
+    r = d // 29 + (d // 28 - d // 29) * (a // 11)
+    og = 21 + d + r
+    sz = 7 - (year_time + year_time // 4 + s) % 7
+    oe = 7 - (og - sz) % 7
+    os = og + oe
+
+    if os > 32:
+        return datetime(year=year_time, month=4, day=(os-31))
+    else:
+        return datetime(year=year_time, month=3, day=os)
+
+
+def thanksgiving_calc(year_time: int) -> datetime:
+    year_out = datetime(year=year_time, month=11, day=29)
+    date_out = datetime(year=year_time, month=11, day=3)
+    return year_out - timedelta(days=(date_out.weekday() + 2))
+
+
+def days_feb(year_time: int) -> int:
+    if int(year_time) % 400 == 0 or int(year_time) % 4 == 0 and not int(year_time) % 100 == 0:
+        return 29
+    else:
+        return 28
+
+
+def year_start(year_time: int) -> datetime:
+    return datetime(year=year_time, month=1, day=1)

--- a/datetimeparser/formulars.py
+++ b/datetimeparser/formulars.py
@@ -14,7 +14,7 @@ def eastern_calc(year_time: int) -> datetime:
     os = og + oe
 
     if os > 32:
-        return datetime(year=year_time, month=4, day=(os-31))
+        return datetime(year=year_time, month=4, day=(os - 31))
     else:
         return datetime(year=year_time, month=3, day=os)
 

--- a/datetimeparser/parsermethods.py
+++ b/datetimeparser/parsermethods.py
@@ -1,5 +1,4 @@
 import re
-import datetime
 from typing import Union, List, Tuple, Optional
 
 from .enums import *
@@ -54,7 +53,7 @@ class AbsoluteDateFormatsParser:
             # Trying to find the right datetime format
             # And then instantly return the parsed datetime
             try:
-                time = datetime.datetime.strptime(string, datetime_format)
+                time = datetime.strptime(string, datetime_format)
             except ValueError:
                 continue
 
@@ -334,7 +333,7 @@ class DatetimeDeltaConstantsParser:
 
             for clocktime_format in self.CLOCKTIME_FORMATS:
                 try:
-                    parsed_time = datetime.datetime.strptime(time, clocktime_format)
+                    parsed_time = datetime.strptime(time, clocktime_format)
                 except ValueError:
                     continue
 


### PR DESCRIPTION
Fixed import in `parser.py`

- due importing all from baseclases, datetime is already imported


Fixed timezone-issue

- time-zones can now be specified 


Added new parameter `time_values` for Constants

- Evaluator now takes the objects directly and not from an dict via names


Created new file `formulas.py` for evaluator functions