### PR TITLE
v0.8rc2: Added year type constants

### DIFF
--- a/datetimeparser/enums.py
+++ b/datetimeparser/enums.py
@@ -211,10 +211,16 @@ class DatetimeConstants:
     WEEKS = Constant('weeks', ['week'])
     MONTHS = Constant('months', ['month'])
     YEARS = Constant('years', ['year'])
+    OLYMPIADS = Constant('olympiads', ['olympiad'])  # 4 years
+    DECADES = Constant('decades', ['decade'])  # 10 years
+    CENTURIES = Constant('centuries', ['century'])  # 100 years
+    MILLENNIUMS = Constant('millenniums', ['millennium'])  # 1,000 years
+    MEGAANNUMS = Constant('megaannuums', ['megaannuum'])  # 1,000,000 years
+    GIGAANNUMS = Constant('gigaannuums', ['gigaannuum'])  # 1,000,000,000 years
 
     TIME = [SECONDS, MINUTES, QUARTERS, HOURS]
-    DATE = [DAYS, WEEKS, MONTHS, YEARS]
-    ALL = [SECONDS, MINUTES, QUARTERS, HOURS, DAYS, WEEKS, MONTHS, YEARS]
+    DATE = [DAYS, WEEKS, MONTHS, YEARS, DECADES, CENTURIES, MILLENNIUMS]
+    ALL = [*DATE, *TIME]
 
     @classmethod
     def convert_from_mini_date(cls, md):

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
   long_description_content_type="text/markdown",
   long_description=long_description,
   packages=['datetimeparser'],
-  version='0.8rc1',  # version number: https://peps.python.org/pep-0440/
+  version='0.8rc2',  # version number: https://peps.python.org/pep-0440/
   license='MIT',
   description='A parser library built for parsing the english language into datetime objects.',
   author='Ari24',


### PR DESCRIPTION
Closes #72 
  
Adds
- olympiads (4 years)
- decades (10 years)
- centuries (100 years)
- millenniums (1,000 years)
- megaannums (1,000,000 years)
- gigaannums (1,000,000,000 years)