### PR TITLE
Added support for new Datetime Constants

### DIFF
--- a/datetimeparser/enums.py
+++ b/datetimeparser/enums.py
@@ -222,7 +222,7 @@ class DatetimeConstants:
     GIGAANNUMS = Constant('gigaannuums', ['gigaannuum'])  # 1,000,000,000 years
 
     TIME = [SECONDS, MINUTES, QUARTERS, HOURS]
-    DATE = [DAYS, WEEKS, MONTHS, YEARS, DECADES, CENTURIES, MILLENNIUMS]
+    DATE = [DAYS, WEEKS, MONTHS, YEARS, DECADES, CENTURIES, MILLENNIUMS, MEGAANNUMS, GIGAANNUMS]
     ALL = [*DATE, *TIME]
 
     @classmethod

--- a/datetimeparser/parsermethods.py
+++ b/datetimeparser/parsermethods.py
@@ -33,6 +33,16 @@ class RelativeDatetimeHelper:
             return RelativeDateTime(months=delta)
         elif keyword == DatetimeConstants.YEARS:
             return RelativeDateTime(years=delta)
+        elif keyword == DatetimeConstants.OLYMPIADS:
+            return RelativeDateTime(years=4)
+        elif keyword == DatetimeConstants.CENTURIES:
+            return RelativeDateTime(years=100)
+        elif keyword == DatetimeConstants.MILLENNIUMS:
+            return RelativeDateTime(years=1000)
+        elif keyword == DatetimeConstants.MEGAANNUMS:
+            return RelativeDateTime(years=1000000)
+        elif keyword == DatetimeConstants.GIGAANNUMS:
+            return RelativeDateTime(years=1000000000)
         elif keyword == DatetimeConstants.HOURS:
             return RelativeDateTime(hours=delta)
         elif keyword == DatetimeConstants.QUARTERS:

--- a/datetimeparser/parsermethods.py
+++ b/datetimeparser/parsermethods.py
@@ -215,22 +215,9 @@ class RelativeDatetimesParser:
             number = new_data.pop(0)
             type_ = new_data.pop(0)
 
-            if type_ in DatetimeConstants.DATE:
-                if type_ == DatetimeConstants.DAYS:
-                    date.days = number
-                elif type_ == DatetimeConstants.WEEKS:
-                    date.weeks = number
-                elif type_ == DatetimeConstants.MONTHS:
-                    date.months = number
-                elif type_ == DatetimeConstants.YEARS:
-                    date.years = number
-            elif type_ in DatetimeConstants.TIME:
-                if type_ == DatetimeConstants.SECONDS:
-                    date.seconds = number
-                elif type_ == DatetimeConstants.MINUTES:
-                    date.minutes = number
-                elif type_ == DatetimeConstants.HOURS:
-                    date.hours = number
+            if type_ in DatetimeConstants.ALL:
+                relative_date = RelativeDatetimeHelper.from_keyword(type_, number)
+                date = RelativeDateTime.concatenate(relative_date, date)
 
         return Method.RELATIVE_DATETIMES, date
 


### PR DESCRIPTION
<!-- Please make sure you follow these guidelines: -->
<!-- - Capitalize the first letter of the PR title -->
<!-- - Length of the title must be under the maximum -->
<!-- - Your title should be a short description about the changes, not including details! -->
<!-- - Make sure to add labels as well -->
<!-- - Bump the version number if necessary -->

## Description about the changes

Added support for the constants
- `OLYMPIADS`
- `CENTURIES`
- `MILENIUMS`
- `MEGAANNUUMS`
- `GIGAANNUUMS`
  
which have been already defined but not implemented in the parser. I also changed the way how the `RelativeDatetimesParser` concatenates the times and dates. Now it makes use of the `RelativeDatetimeHelper` class


## Testcases that have been added

None


## Constants that have been added

None


## Python Version you tested this feature on

- [x] Python 3.7
- [ ] Python 3.8
- [ ] Python 3.9
- [ ] Python 3.10
- [ ] Python 3.11


