### PR TITLE
Provieded dunder details

### DIFF
--- a/datetimeparser/datetimeparser.py
+++ b/datetimeparser/datetimeparser.py
@@ -1,3 +1,11 @@
+"""
+Main module which provides the parse function.
+"""
+
+__all__ = ['parse', '__version__', '__author__']
+__version__ = "0.10.3"
+__author__ = "aridevelopment"
+
 import datetime
 from typing import Union
 

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,10 @@
 from distutils.core import setup
+from pathlib import Path
+
+from datetimeparser.datetimeparser import __version__
+
 
 # for the readme
-from pathlib import Path
 this_directory = Path(__file__).parent
 long_description = (this_directory / "README.md").read_text(encoding="utf-8")
 
@@ -10,7 +13,7 @@ setup(
   long_description_content_type="text/markdown",
   long_description=long_description,
   packages=['datetimeparser'],
-  version='0.10rc2',  # version number: https://peps.python.org/pep-0440/
+  version=".".join(__version__.split(".")[:2]) + "rc1." + __version__.split(".")[2],  # version number: https://peps.python.org/pep-0440/
   license='MIT',
   description='A parser library built for parsing the english language into datetime objects.',
   author='Ari24',


### PR DESCRIPTION
<!-- Please make sure you follow these guidelines: -->
<!-- - Capitalize the first letter of the PR title -->
<!-- - Length of the title must be under the maximum -->
<!-- - Your title should be a short description about the changes, not including details! -->
<!-- - Make sure to add labels as well -->
<!-- - Bump the version number if necessary -->

## Description about the changes

I removed the hardcoded version value in setup.py. It now imports the version from datetimeparser.py which also now includes module level dunder details: `__all__`, `__version__` and `__author__`. The version in datetimeparser.py now doesn't have to follow pep-0440 standards anymore but the following layout: `majorN.minorN.devN` where as `N` indicates a number.


## Testcases that have been added

None


## Constants that have been added

None


## Python Version you tested this feature on

- [x] Python 3.7
- [ ] Python 3.8
- [ ] Python 3.9
- [ ] Python 3.10
- [ ] Python 3.11


