### PR TITLE
Changed DatetimeDeltaConstantsParser return type to AbsoluteDateTime

### DIFF
--- a/datetimeparser/datetimeparser.py
+++ b/datetimeparser/datetimeparser.py
@@ -3,7 +3,7 @@ Main module which provides the parse function.
 """
 
 __all__ = ['parse', '__version__', '__author__']
-__version__ = "0.10.3"
+__version__ = "0.10.4"
 __author__ = "aridevelopment"
 
 import datetime

--- a/datetimeparser/parsermethods.py
+++ b/datetimeparser/parsermethods.py
@@ -537,7 +537,7 @@ class DatetimeDeltaConstantsParser:
         "%H:%M"
     )
 
-    def parse(self, string: str) -> Optional[Tuple[MethodEnum, RelativeDateTime]]:  # noqa: C901
+    def parse(self, string: str) -> Optional[Tuple[MethodEnum, AbsoluteDateTime]]:  # noqa: C901
         """
         Parses strings like "at 3pm tomorrow" or "at 1am" or "at 10:30" or "at 17"
         Returns None if the string cannot be parsed
@@ -571,19 +571,19 @@ class DatetimeDeltaConstantsParser:
             # e.g. "3(pm|am)", return that time respecting the after_midday flag
             if not parsed_time and time.count(":") == 0 and parse_int(time) is not None:
                 if after_midday is not None:
-                    parsed_time = RelativeDateTime(hours=(12 if after_midday else 0) + int(time))
+                    parsed_time = AbsoluteDateTime(hour=(12 if after_midday else 0) + int(time))
                 else:
-                    parsed_time = RelativeDateTime(hours=int(time))
+                    parsed_time = AbsoluteDateTime(hour=int(time))
             elif parsed_time:
                 if after_midday is not None:
-                    parsed_time = RelativeDateTime(hours=(12 if after_midday else 0) + parsed_time.hour, minutes=parsed_time.minute, seconds=parsed_time.second)
+                    parsed_time = AbsoluteDateTime(hour=(12 if after_midday else 0) + parsed_time.hour, minute=parsed_time.minute, second=parsed_time.second)
                 else:
-                    parsed_time = RelativeDateTime(hours=parsed_time.hour, minutes=parsed_time.minute, seconds=parsed_time.second)
+                    parsed_time = AbsoluteDateTime(hour=parsed_time.hour, minute=parsed_time.minute, second=parsed_time.second)
             else:
                 return None
 
             # If the time is invalid return None
-            if parsed_time.hours > 23 or parsed_time.minutes > 59 or parsed_time.seconds > 59:
+            if parsed_time.hour > 23 or parsed_time.minute > 59 or parsed_time.second > 59:
                 return None
 
             # If there's no more content left
@@ -616,10 +616,10 @@ class DatetimeDeltaConstantsParser:
                     return None
 
                 # Value is either 0 or 12 (depending on the constant)
-                parsed_time.hours += value
+                parsed_time.hour += value
 
                 # If the time is invalid return None
-                if parsed_time.hours > 23:
+                if parsed_time.hour > 23:
                     return None
 
                 return Method.DATETIME_DELTA_CONSTANTS, parsed_time
@@ -821,7 +821,7 @@ class AbsolutePrepositionParser:
             if result is not None:
                 return result[1]
 
-            # Try datetime delta constants (e.g. "(two quarters past) five")
+            # Try datetime delta constants (e.g. "(two quarters past) 5pm")
             datetime_delta_parser = DatetimeDeltaConstantsParser()
             result = datetime_delta_parser.parse(data)
 


### PR DESCRIPTION
<!-- Please make sure you follow these guidelines: -->
<!-- - Capitalize the first letter of the PR title -->
<!-- - Length of the title must be under the maximum -->
<!-- - Your title should be a short description about the changes, not including details! -->
<!-- - Make sure to add labels as well -->
<!-- - Bump the version number if necessary -->

## Description about the changes

The old return type of `DatetimeDeltaConstantsParser` was `RelativeDateTime`. This has now been changed to `AbsoluteDateTime` as it makes more sense to have `1am` as an absolute time. This also fixes an issue in the evaluator in absolute prepositions for testcases like `3 hours past 5pm`.


## Testcases that have been added

None


## Constants that have been added

None


## Python Version you tested this feature on

- [x] Python 3.7
- [ ] Python 3.8
- [ ] Python 3.9
- [ ] Python 3.10
- [ ] Python 3.11


