### PR TITLE
Added evaluation for relative times + fixed an invalid testcase

### DIFF
--- a/datetimeparser/datetimeparser.py
+++ b/datetimeparser/datetimeparser.py
@@ -3,7 +3,7 @@ Main module which provides the parse function.
 """
 
 __all__ = ['parse', '__version__', '__author__']
-__version__ = "0.10.4"
+__version__ = "0.11.4"
 __author__ = "aridevelopment"
 
 import datetime

--- a/tests/testcases.py
+++ b/tests/testcases.py
@@ -103,7 +103,7 @@ testcases = {
     "quarter past 5pm": datetime(today.year, today.month, today.day, 17, 15, 0),
     "two quarters past 5h": datetime(today.year, today.month, today.day, 17, 30, 0),
     "one quarter before 10pm": datetime(today.year, today.month, today.day, 21, 45, 0),
-    "ten quarters after 03:01:10am": datetime(today.year, today.month, today.day, 5, 41, 10),
+    "ten quarters after 03:01:10am": datetime(today.year, today.month, today.day, 5, 31, 10),
     "hour past christmas": datetime(today.year, 12, 25, 1),
     "30 minutes past easter": None
 }


### PR DESCRIPTION
<!-- Please make sure you follow these guidelines: -->
<!-- - Capitalize the first letter of the PR title -->
<!-- - Length of the title must be under the maximum -->
<!-- - Your title should be a short description about the changes, not including details! -->
<!-- - Make sure to add labels as well -->
<!-- - Bump the version number if necessary -->

## Description about the changes

- fixed an invalid testcase
- added evaluation for relative times: f.e. `quarter past 5pm`
- rewrote some broken code caused by parser returning other output types


## Testcases that have been added (edited)

- "ten quarters after 03:01:10am": `datetime(today.year, today.month, today.day, 5, 31, 10)`


## Constants that have been added

- None


## Python Version you tested this feature on

- [ ] Python 3.7
- [ ] Python 3.8
- [X] Python 3.9
- [ ] Python 3.10
- [ ] Python 3.11


