### PR TITLE
Fixed invalid test_case "two quarters past 5h"

### DIFF
--- a/tests/testcases.py
+++ b/tests/testcases.py
@@ -101,7 +101,7 @@ testcases = {
     "5 in the morning": datetime(today.year, today.month, today.day, 5),
     # GitHub issue #78
     "quarter past 5pm": datetime(today.year, today.month, today.day, 17, 15, 0),
-    "two quarters past 5h": datetime(today.year, today.month, today.day, 17, 30, 0),
+    "two quarters past 5h": datetime(today.year, today.month, today.day, 5, 30, 0),
     "one quarter before 10pm": datetime(today.year, today.month, today.day, 21, 45, 0),
     "ten quarters after 03:01:10am": datetime(today.year, today.month, today.day, 5, 31, 10),
     "hour past christmas": datetime(today.year, 12, 25, 1),


### PR DESCRIPTION
<!-- Please make sure you follow these guidelines: -->
<!-- - Capitalize the first letter of the PR title -->
<!-- - Length of the title must be under the maximum -->
<!-- - Your title should be a short description about the changes, not including details! -->
<!-- - Make sure to add labels as well -->
<!-- - Bump the version number if necessary -->

## Description about the changes
- Fixed an invalid testcase `"two quarters past 5h"`


## Testcases that have been added

- None


## Constants that have been added

- None


## Python Version you tested this feature on

- [ ] Python 3.7
- [ ] Python 3.8
- [X] Python 3.9
- [ ] Python 3.10
- [ ] Python 3.11


