### PR TITLE
Made `infinity` raise an exception + removed integer-return-type from…

### DIFF
--- a/datetimeparser/datetimeparser.py
+++ b/datetimeparser/datetimeparser.py
@@ -3,7 +3,7 @@ Main module which provides the parse function.
 """
 
 __all__ = ['parse', '__version__', '__author__']
-__version__ = "0.11.4"
+__version__ = "0.11.5"
 __author__ = "aridevelopment"
 
 import datetime
@@ -13,15 +13,14 @@ from datetimeparser.evaluator import Evaluator
 from datetimeparser.parser import Parser
 
 
-def parse(datetime_string: str, timezone: str = "Europe/Berlin") -> Union[datetime.datetime, int, None]:
+def parse(datetime_string: str, timezone: str = "Europe/Berlin") -> Union[datetime.datetime, None]:
     """
     Parses a datetime string and returns a datetime object.
-    -1 is returned if the result is Infinity.
     If the datetime string cannot be parsed, None is returned.
 
     :param datetime_string: The datetime string to parse.
     :param timezone: The timezone to use. Should be a valid timezone for pytz.timezone(). Default: Europe/Berlin
-    :return: A datetime object or an integer or None
+    :return: A datetime object or None
     """
     parser_result = Parser(datetime_string).parse()
 

--- a/datetimeparser/enums.py
+++ b/datetimeparser/enums.py
@@ -74,7 +74,7 @@ class Constants:
     BEGIN_OF_YEAR = Constant('begin of year', ['the begin of year', 'the begin of the year', 'begin of the year'],
                              options=[ConstantOption.YEAR_VARIABLE], time_value=year_start)
 
-    INFINITY = Constant('infinity', ['inf'], value=-1)
+    INFINITY = Constant('infinity', ['inf'], value=None)
 
     TODAY = Constant('today', options=[ConstantOption.TIME_VARIABLE], time_value=lambda _: datetime(datetime.today().year, datetime.today().month, datetime.today().day))
     TOMORROW = Constant('tomorrow', options=[ConstantOption.TIME_VARIABLE], time_value=lambda _: datetime(datetime.today().year, datetime.today().month, datetime.today().day) + relativedelta(days=1))

--- a/datetimeparser/evaluator.py
+++ b/datetimeparser/evaluator.py
@@ -24,7 +24,7 @@ class Evaluator:
         self.current_datetime: datetime = datetime.strptime(datetime.strftime(datetime.now(tz=tiz), "%Y-%m-%d %H:%M:%S"), "%Y-%m-%d %H:%M:%S")
         self.offset = tiz.utcoffset(self.current_datetime)
 
-    def evaluate(self) -> Union[datetime, int, None]:
+    def evaluate(self) -> Union[datetime, None]:
         ev_out = None
         ev = EvaluatorMethods(self.parsed_object_content, self.current_datetime, self.offset)
 

--- a/datetimeparser/evaluatormethods.py
+++ b/datetimeparser/evaluatormethods.py
@@ -1,5 +1,3 @@
-from typing import Union
-
 from .baseclasses import *
 from .enums import *
 
@@ -237,7 +235,7 @@ class EvaluatorMethods(EvaluatorUtils):
 
         return self.remove_milli_seconds(base)
 
-    def evaluate_constants(self) -> Union[datetime, int]:
+    def evaluate_constants(self) -> datetime:
         dt: datetime = self.current_time
         object_type: Constant = self.parsed[0]
 
@@ -251,7 +249,7 @@ class EvaluatorMethods(EvaluatorUtils):
 
         else:
             if object_type.name == "infinity":
-                return object_type.value
+                raise ValueError("'infinity' isn't a valid time")
 
             elif object_type in WeekdayConstants.ALL:
                 dt: datetime = datetime.strptime(

--- a/tests/testcases.py
+++ b/tests/testcases.py
@@ -28,8 +28,8 @@ testcases = {
     "3 minutes and 4 hours, 2 seconds after new years eve 2000": datetime(year=2000, month=12, day=31, hour=4, minute=3, second=2),
     "2 days after christmas 2023": datetime(year=2023, month=12, day=27),
     # Infinity
-    "infinity": -1,
-    "inf": -1,
+    "infinity": None,
+    "inf": None,
     # Relative Datetimes
     "in 1 Year 2 months 3 weeks 4 days 5 hours 6 minutes 7 seconds": today + relativedelta(years=1, months=2, weeks=3, days=4, hours=5, minutes=6, seconds=7),
     "in a year and in 2 months, in 3 seconds and 4 days": today + relativedelta(years=1, months=2, days=4, seconds=3),


### PR DESCRIPTION
… methods + changed infinity-value to None

<!-- Please make sure you follow these guidelines: -->
<!-- - Capitalize the first letter of the PR title -->
<!-- - Length of the title must be under the maximum -->
<!-- - Your title should be a short description about the changes, not including details! -->
<!-- - Make sure to add labels as well -->
<!-- - Bump the version number if necessary -->

## Description about the changes

- raise an exception if `infinity` is used, because it does not set a valid time
- removed integer return type in comments and methods -> now just returns datetime or None
- infinity-testcase and constant where set to `None`


## Testcases that was edited

- infinity: `None`

## Constants that was edited

- infinity: `None`


## Python Version you tested this feature on

- [ ] Python 3.7
- [ ] Python 3.8
- [X] Python 3.9
- [ ] Python 3.10
- [ ] Python 3.11


