### PR TITLE
Fixed wrong output (xy of ...)

### DIFF
--- a/datetimeparser/datetimeparser.py
+++ b/datetimeparser/datetimeparser.py
@@ -3,7 +3,7 @@ Main module which provides the parse function.
 """
 
 __all__ = ['parse', '__version__', '__author__']
-__version__ = "0.11.6"
+__version__ = "0.11.7"
 __author__ = "aridevelopment"
 
 import datetime

--- a/datetimeparser/evaluatorutils.py
+++ b/datetimeparser/evaluatorutils.py
@@ -17,10 +17,10 @@ class EvaluatorUtils:
         """
         for index, element in enumerate(parsed_list):
             if isinstance(element, Constant) and element.name == "of":
-                if isinstance(parsed_list[index-1], RelativeDateTime):
-                    if parsed_list[index-1].years != 0:
-                        parsed_list[index-1].years -= 1
-                    if parsed_list[index-1].months != 0:
+                if isinstance(parsed_list[index - 1], RelativeDateTime):
+                    if parsed_list[index - 1].years != 0:
+                        parsed_list[index - 1].years -= 1
+                    if parsed_list[index - 1].months != 0:
                         parsed_list[index - 1].months -= 1
 
         return [element for element in parsed_list if element not in Keywords.ALL and not isinstance(element, str)]

--- a/datetimeparser/evaluatorutils.py
+++ b/datetimeparser/evaluatorutils.py
@@ -15,6 +15,13 @@ class EvaluatorUtils:
         :param parsed_list: The list that should be sanitized
         :return: list
         """
+        for index, element in enumerate(parsed_list):
+            if isinstance(element, Constant) and element.name == "of":
+                if isinstance(parsed_list[index-1], RelativeDateTime):
+                    if parsed_list[index-1].years != 0:
+                        parsed_list[index-1].years -= 1
+                    if parsed_list[index-1].months != 0:
+                        parsed_list[index - 1].months -= 1
 
         return [element for element in parsed_list if element not in Keywords.ALL and not isinstance(element, str)]
 


### PR DESCRIPTION
<!-- Please make sure you follow these guidelines: -->
<!-- - Capitalize the first letter of the PR title -->
<!-- - Length of the title must be under the maximum -->
<!-- - Your title should be a short description about the changes, not including details! -->
<!-- - Make sure to add labels as well -->
<!-- - Bump the version number if necessary -->

## Description about the changes

Fixed the wrong output from testcases like `fifth month of xy`, returning the sixth month of xy, due to the fact that datetimeobjects start at month 1.


## Python Version you tested this feature on

- [ ] Python 3.7
- [ ] Python 3.8
- [X] Python 3.9
- [ ] Python 3.10
- [ ] Python 3.11


