### PR TITLE
v0.11.8: Added years to Constants Relative Extension Parser

### DIFF
--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -4,8 +4,12 @@
 name: Python Lint
 
 on:
-- push
-- pull_request
+  push:
+    branches:
+      - main
+  pull_request:
+    branches-ignore:
+      - no_checks
 
 jobs:
   build:

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -4,8 +4,12 @@
 name: Python Tests
 
 on:
-- push
-- pull_request
+  push:
+    branches:
+      - main
+  pull_request:
+    branches-ignore:
+      - no_checks
 
 jobs:
   build:

--- a/datetimeparser/datetimeparser.py
+++ b/datetimeparser/datetimeparser.py
@@ -3,7 +3,7 @@ Main module which provides the parse function.
 """
 
 __all__ = ['parse', '__version__', '__author__']
-__version__ = "0.11.7"
+__version__ = "0.11.8"
 __author__ = "aridevelopment"
 
 import datetime


### PR DESCRIPTION
<!-- Please make sure you follow these guidelines: -->
<!-- - Capitalize the first letter of the PR title -->
<!-- - Length of the title must be under the maximum -->
<!-- - Your title should be a short description about the changes, not including details! -->
<!-- - Make sure to add labels as well -->
<!-- - Bump the version number if necessary -->

## Description about the changes

- Cleanup of code
- Added years to the Constants Relative Extension Parser: `daylight change monday 2020`
- Added new rules for branches to GitHub ci
- Bumped version from `v.0.11.8` to `v.0.11.8`


## Python Version you tested this feature on

- [x] Python 3.7
- [ ] Python 3.8
- [ ] Python 3.9
- [ ] Python 3.10
- [ ] Python 3.11


