### PR TITLE
Absolute Preposition Parser does now parse absolute datetime formats

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -32,4 +32,4 @@ jobs:
       shell: bash
       working-directory: tests
       run: |
-        python runtests.py -s
+        python runtests.py

--- a/datetimeparser/datetimeparser.py
+++ b/datetimeparser/datetimeparser.py
@@ -3,7 +3,7 @@ Main module which provides the parse function.
 """
 
 __all__ = ['parse', '__version__', '__author__']
-__version__ = "0.12.0"
+__version__ = "0.12.1"
 __author__ = "aridevelopment"
 
 import datetime

--- a/datetimeparser/parsermethods.py
+++ b/datetimeparser/parsermethods.py
@@ -160,8 +160,8 @@ class RelativeDatetimesParser:
                     not_possible = False
                     break
 
-            # If the argument is a datetime keyword (e.g. "year", "month", ...) add the keyword to the list
-            # Prepends a 1 if there wasn't a number set before the keyword (e.g. "months (and three days)" doesn't make any sense, so we prepend it with a 1)
+            # If the argument is a datetime keyword (e.g. "year", "month", ...) add the keyword to the list Prepends a 1 if there wasn't
+            # a number set before the keyword (e.g. "months (and three days)" doesn't make any sense, so we prepend it with a 1)
             for keyword in DatetimeConstants.ALL:
                 if argument.lower() in keyword.get_all():
                     if not new_data:
@@ -599,7 +599,11 @@ class DatetimeDeltaConstantsParser:
                     parsed_time = AbsoluteDateTime(hour=int(time))
             elif parsed_time:
                 if after_midday is not None:
-                    parsed_time = AbsoluteDateTime(hour=(12 if after_midday else 0) + parsed_time.hour, minute=parsed_time.minute, second=parsed_time.second)
+                    parsed_time = AbsoluteDateTime(
+                        hour=(12 if after_midday else 0) + parsed_time.hour,
+                        minute=parsed_time.minute,
+                        second=parsed_time.second
+                    )
                 else:
                     parsed_time = AbsoluteDateTime(hour=parsed_time.hour, minute=parsed_time.minute, second=parsed_time.second)
             else:
@@ -849,7 +853,7 @@ class AbsolutePrepositionParser:
             result = datetime_delta_parser.parse(data)
 
             if result is not None:
-                return (result[1],)
+                return result[1],
 
             return None
         else:

--- a/datetimeparser/parsermethods.py
+++ b/datetimeparser/parsermethods.py
@@ -839,7 +839,7 @@ class AbsolutePrepositionParser:
 
             # If the result is None there may be just a normal year (e.g. "(three days after) 2018")
             if parse_int(data):
-                return (AbsoluteDateTime(year=int(data)),)
+                return AbsoluteDateTime(year=int(data)),
 
             # Try relative constants (e.g. "(2 hours after) daylight change yesterday")
             constant_relative_extensions_parser = ConstantRelativeExtensionsParser()
@@ -851,6 +851,13 @@ class AbsolutePrepositionParser:
             # Try datetime delta constants (e.g. "(two quarters past) 5pm")
             datetime_delta_parser = DatetimeDeltaConstantsParser()
             result = datetime_delta_parser.parse(data)
+
+            if result is not None:
+                return result[1],
+
+            # Try absolute datetime formats (e.g. "(30 hours after) 30.01.2018")
+            absolute_datetime_format_parser = AbsoluteDateFormatsParser()
+            result = absolute_datetime_format_parser.parse(data)
 
             if result is not None:
                 return result[1],

--- a/tests/testcases.py
+++ b/tests/testcases.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
+from pytz import timezone
 
 
 class ThrowException:
@@ -18,7 +19,7 @@ class ReturnNone:
         return "ReturnNone"
 
 
-today = datetime.strptime(datetime.today().strftime("%Y-%m-%d %H:%M:%S"), "%Y-%m-%d %H:%M:%S")
+today = datetime.strptime(datetime.now(tz=timezone("Europe/Berlin")).strftime("%Y-%m-%d %H:%M:%S"), "%Y-%m-%d %H:%M:%S")
 
 testcases = {
     # Absolute datetime formats

--- a/tests/testcases.py
+++ b/tests/testcases.py
@@ -53,7 +53,9 @@ testcases = {
         "one quarter before 10pm": datetime(today.year, today.month, today.day, 21, 45, 0),
         "ten quarters after 03:01:10am": datetime(today.year, today.month, today.day, 5, 31, 10),
         "hour past christmas": datetime(today.year, 12, 25, 1),
-        "30 minutes past easter": None
+        "30 minutes past easter": None,
+        # GitHub issue #158
+        "30 hours after 30.03.2020": datetime(year=2020, month=3, day=31, hour=6)
     },
     # Relative Datetimes
     "relative_datetimes": {


### PR DESCRIPTION
<!-- Please make sure you follow these guidelines: -->
<!-- - Capitalize the first letter of the PR title -->
<!-- - Length of the title must be under the maximum -->
<!-- - Your title should be a short description about the changes, not including details! -->
<!-- - Make sure to add labels as well -->
<!-- - Bump the version number if necessary -->

## Description about the changes

Closes #158 
- The absolute preposition parser did not parse absolute datetime formats before (e.g. "(30 hours after) 30.03.2020"). This has now been fixed
- Fixed style issues
- Fixes the GitHub testrunner


## Testcases that have been added

- ``30 hours after 30.03.2020``: ``datetime(year=2020, month=3, day=31, hour=4)``


## Python Version you tested this feature on

- [ ] Python 3.7
- [ ] Python 3.8
- [ ] Python 3.9
- [x] Python 3.10
- [ ] Python 3.11


