### PR TITLE
Fixed matrix strategy failing-fast

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -15,6 +15,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
 


### PR DESCRIPTION
<!-- Please make sure you follow these guidelines: -->
<!-- - Capitalize the first letter of the PR title -->
<!-- - Length of the title must be under the maximum -->
<!-- - Your title should be a short description about the changes, not including details! -->
<!-- - Make sure to add labels as well -->
<!-- - Bump the version number if necessary -->

## Description about the changes

Before, if one or more jobs from one task failed, others would also immediatly cancel. This is now fixed by setting fail-fast to false as it's set to true on default. See [https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#handling-failures](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#handling-failures)


