### PR TITLE
retrieve `__version__` via regex (fixes #200)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,15 @@
+import re
 from distutils.core import setup
 from pathlib import Path
-
-from datetimeparser.datetimeparser import __version__
 
 
 # for the readme
 this_directory = Path(__file__).parent
+__version__ = re.search(
+  r"^__version__\s*=\s*[\'\"]([^\'\"]*)[\'\"]",
+  this_directory.joinpath("datetimeparser/datetimeparser.py").read_text(encoding="utf-8"),
+  re.MULTILINE
+).group(1)
 long_description = (this_directory / "README.md").read_text(encoding="utf-8")
 
 setup(


### PR DESCRIPTION
make `__version__` being retrieved via regex inside `setup.py` to avoid imports of requirements (which aren't installed at the moment of execution)

fixes #200