### PR TITLE
Fix version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
   name='python-datetimeparser',
   long_description_content_type="text/markdown",
   long_description=long_description,
-  version=".".join(__version__.split(".")[:2]) + "rc1." + __version__.split(".")[2],  # version number: https://peps.python.org/pep-0440/
+  version=__version__,
   license='MIT',
   description='A parser library built for parsing the english language into datetime objects.',
   author='Ari24',


### PR DESCRIPTION
During installation following error occurs:
```py
SetuptoolsDeprecationWarning: Invalid version: '0.15rc1.0'

###################
# Invalid version #
###################
'0.15rc1.0' is not valid according to PEP 440.

Please make sure specify a valid version for your package.
Also note that future releases of setuptools may halt the build process
if an invalid version is given.
```
> installed via `python-datetimeparser @ git+https://github.com/aridevelopment-de/datetimeparser.git@dev`



## Python Version you tested this feature on

- [ ] Python 3.7
- [ ] Python 3.8
- [ ] Python 3.9
- [ ] Python 3.10
- [x] Python 3.11


