### PR TITLE
Added parsing and evaluating of `first monday of august`

### DIFF
--- a/datetimeparser/evaluator/evaluatorutils.py
+++ b/datetimeparser/evaluator/evaluatorutils.py
@@ -143,7 +143,6 @@ class EvaluatorUtils:
         if isinstance(sanitized_input[-1], AbsoluteDateTime):
             # The Constant that the AbsoluteDateTime object should be based on (the year)
             if isinstance(sanitized_input[-2], Constant):
-                print(sanitized_input[-2].name, sanitized_input)
                 # An Integer giving the information about the 'x'th of something (f.e. "first of august")
                 if isinstance(sanitized_input[-3], int):
                     dt: datetime = sanitized_input[-2].time_value(sanitized_input[-1].year)
@@ -152,7 +151,6 @@ class EvaluatorUtils:
 
                 if sanitized_input[-2].time_value:
                     dt = sanitized_input[-2].time_value(sanitized_input[-1].year)
-                    print(dt)
 
                     if isinstance(sanitized_input[-3], Constant) and sanitized_input[-3].value:
                         dt += relativedelta(days=sanitized_input[-3].value - 1)

--- a/datetimeparser/evaluator/evaluatorutils.py
+++ b/datetimeparser/evaluator/evaluatorutils.py
@@ -172,14 +172,13 @@ class EvaluatorUtils:
 
                     return dt
 
-                else:
-                    if sanitized_input[-3].value:
-                        val: int = sanitized_input[-3].value
+                elif sanitized_input[-3].value:
+                    val: int = sanitized_input[-3].value
 
-                        if sanitized_input[-2].name == "days":
-                            return datetime(sanitized_input[-1].year, 1, val, 0, 0, 0)
-                        if sanitized_input[-2].name == "months":
-                            return datetime(sanitized_input[-1].year, val, 1, 0, 0, 0)
+                    if sanitized_input[-2].name == "days":
+                        return datetime(sanitized_input[-1].year, 1, val, 0, 0, 0)
+                    if sanitized_input[-2].name == "months":
+                        return datetime(sanitized_input[-1].year, val, 1, 0, 0, 0)
 
             # If a year is given but no months/days, they will be set to '1' because datetime can't handle month/day-values with '0'
             if sanitized_input[-1].year != 0:

--- a/datetimeparser/parser/parsermethods.py
+++ b/datetimeparser/parser/parsermethods.py
@@ -676,6 +676,7 @@ class AbsolutePrepositionParser:
     )
 
     RELATIVE_DATETIME_CONSTANTS = (*NumberCountConstants.ALL, *NumberConstants.ALL, *DatetimeConstants.ALL)
+    ABSOLUTE_RELATIVE_DATETIME_CONSTANTS = (*WeekdayConstants.ALL, *MonthConstants.ALL)
     RELATIVE_TIME_CONSTANTS = DatetimeConstants.ALL
 
     RELATIVE_DATA_SKIPPABLE_WORDS = (
@@ -755,6 +756,8 @@ class AbsolutePrepositionParser:
                 returned_data.append(int(argument))
                 continue
 
+            found_keyword = False
+
             # '1st', '1.', 'first', ...
             # 'one', 'two', 'three', ...
             # 'seconds', 'minutes', 'hours', ...
@@ -766,15 +769,27 @@ class AbsolutePrepositionParser:
                             returned_data.append(1)
 
                         returned_data.append(keyword)
+                    elif keyword in NumberCountConstants.ALL:
+                        if not returned_data:
+                            # The keyword comes before the actual datetime constant 'second (monday of August)'
+                            returned_data.append(keyword)
                     else:
                         returned_data.append(keyword.value)
 
+                    found_keyword = True
                     break
-                else:
-                    continue
 
-                break
-            else:
+            # 'monday', 'tuesday', 'wednesday', ...
+            # 'january', 'february', 'march', ...
+            # GitHub issue #198
+            for keyword in self.ABSOLUTE_RELATIVE_DATETIME_CONSTANTS:
+                if argument in keyword.get_all():
+                    returned_data.append(keyword)
+
+                    found_keyword = True
+                    break
+
+            if not found_keyword:
                 return None
 
         return returned_data
@@ -824,6 +839,9 @@ class AbsolutePrepositionParser:
                     else:
                         # Otherwise, we cannot concatenate both parts of the data, so we just append the current one
                         returned_data.append(current_data)
+            elif value in NumberCountConstants.ALL and unit in (*DatetimeConstants.ALL, *WeekdayConstants.ALL, *MonthConstants.ALL):
+                returned_data.append(value)
+                returned_data.append(unit)
 
         return returned_data
 

--- a/datetimeparser/parser/parsermethods.py
+++ b/datetimeparser/parser/parsermethods.py
@@ -764,7 +764,7 @@ class AbsolutePrepositionParser:
             for keyword in self.RELATIVE_DATETIME_CONSTANTS:
                 if argument in keyword.get_all():
                     if keyword in DatetimeConstants.ALL:
-                        if not returned_data or not isinstance(returned_data[-1], int):
+                        if not returned_data or (not isinstance(returned_data[-1], int) and not returned_data[-1] in NumberCountConstants.ALL):
                             # For cases like 'day and month (before christmas)'
                             returned_data.append(1)
 

--- a/tests/testcases.py
+++ b/tests/testcases.py
@@ -106,6 +106,8 @@ testcases = {
         # GitHub issue #176
         "10 days after pi-day": Expected(time_sensitive=True, month=3, day=14, delta=relativedelta(days=10)),
         "10 days before tau day": Expected(time_sensitive=True, month=6, day=28, delta=relativedelta(days=-10)),
+        # GitHub issue #198
+        "second monday of august 2023": Expected(year=2023, month=8, day=7),
     },
     # Relative Datetimes
     "relative_datetimes": {

--- a/tests/testcases.py
+++ b/tests/testcases.py
@@ -107,7 +107,7 @@ testcases = {
         "10 days after pi-day": Expected(time_sensitive=True, month=3, day=14, delta=relativedelta(days=10)),
         "10 days before tau day": Expected(time_sensitive=True, month=6, day=28, delta=relativedelta(days=-10)),
         # GitHub issue #198
-        "second monday of august 2023": Expected(year=2023, month=8, day=7),
+        "second monday of august 2023": Expected(year=2023, month=8, day=14),
     },
     # Relative Datetimes
     "relative_datetimes": {


### PR DESCRIPTION
<!-- Please make sure you follow these guidelines: -->
<!-- - Capitalize the first letter of the PR title -->
<!-- - Length of the title must be under the maximum -->
<!-- - Your title should be a short description about the changes, not including details! -->
<!-- - Make sure to add labels as well -->
<!-- - Bump the version number if necessary -->

## Description about the changes

`First monday of august` should be considered an absolute preposition but it never got parsed in the first place. This pull requests adds the missing functionality to add this grammar.

Closes #198 


## Testcases that have been added

- ``second monday of august 2023``: ``Expected(year=2023, month=8, day=7)``


## Python Version you tested this feature on

- [ ] Python 3.7
- [ ] Python 3.8
- [ ] Python 3.9
- [x] Python 3.10
- [ ] Python 3.11


